### PR TITLE
hacking on include script generation:

### DIFF
--- a/Paket.LoadingScripts/Paket.LoadingScripts.fsproj
+++ b/Paket.LoadingScripts/Paket.LoadingScripts.fsproj
@@ -44,6 +44,8 @@
     <Compile Include="LoadingScriptsGenerator.fs" />
     <None Include="Script.fsx" />
     <None Include="paket.references" />
+    <None Include="Scripts\load-references-debug.fsx" />
+    <None Include="Scripts\load-project-debug.fsx" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Paket.Core\Paket.Core.fsproj">
@@ -76,6 +78,17 @@
   </Target>
   -->
   <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
+      <ItemGroup>
+        <Reference Include="Chessie">
+          <HintPath>..\packages\Chessie\lib\net40\Chessie.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0' Or $(TargetFrameworkVersion) == 'v3.5')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
@@ -85,7 +98,7 @@
         </Reference>
       </ItemGroup>
     </When>
-    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1')">
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\packages\FSharp.Core\lib\net40\FSharp.Core.dll</HintPath>
@@ -134,6 +147,139 @@
       <ItemGroup>
         <Reference Include="FSharp.Core">
           <HintPath>..\packages\FSharp.Core\lib\portable-net45+netcore45+wpa81+wp8\FSharp.Core.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net35\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net35\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net35\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net35\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v2.0' Or $(TargetFrameworkVersion) == 'v3.0')">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net20\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net20\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net20\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net40\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Mdb">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net45\Mono.Cecil.Mdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Pdb">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net45\Mono.Cecil.Pdb.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net45\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\net45\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0'">
+      <ItemGroup>
+        <Reference Include="Mono.Cecil.Rocks">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\sl5\Mono.Cecil.Rocks.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Mono.Cecil">
+          <HintPath>..\packages\scriptbuilder\Mono.Cecil\lib\sl5\Mono.Cecil.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0' Or $(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6' Or $(TargetFrameworkVersion) == 'v4.6.1' Or $(TargetFrameworkVersion) == 'v4.6.2')">
+      <ItemGroup>
+        <Reference Include="QuickGraph.Data">
+          <HintPath>..\packages\scriptbuilder\QuickGraph\lib\net4\QuickGraph.Data.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="QuickGraph.Graphviz">
+          <HintPath>..\packages\scriptbuilder\QuickGraph\lib\net4\QuickGraph.Graphviz.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="QuickGraph.Serialization">
+          <HintPath>..\packages\scriptbuilder\QuickGraph\lib\net4\QuickGraph.Serialization.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="QuickGraph">
+          <HintPath>..\packages\scriptbuilder\QuickGraph\lib\net4\QuickGraph.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/Paket.LoadingScripts/Script.fsx
+++ b/Paket.LoadingScripts/Script.fsx
@@ -4,8 +4,10 @@ open System.IO
 open System.Linq
 open Mono.Cecil
 open QuickGraph
-let rootFolder        = (__SOURCE_DIRECTORY__) |> DirectoryInfo
+
 let dependenciesFile, lockFile =
+  //let rootFolder = (@"C:\dev\src\g\fiddle3d") |> DirectoryInfo
+  let rootFolder = (__SOURCE_DIRECTORY__) |> DirectoryInfo
   let deps = Paket.Dependencies.Locate(rootFolder.FullName)
   let lock =
     deps.DependenciesFile
@@ -20,9 +22,6 @@ let getDllFilesWithinPackage (paketDependencies: Paket.Dependencies) packageName
     let groupName = None
     paketDependencies.GetInstalledPackageModel(groupName, packageName)
 
-  for p in installModel.ReferenceFileFolders do
-    printfn "reference file folders: %A" p
-  
   // HACK: take first one for now
   let references = installModel.ReferenceFileFolders.[0].Files.References
 
@@ -102,7 +101,7 @@ let packagesGraph = computePackageTopologyGraph lockFile
 
 for (group, package) in packagesGraph.Keys do
   
-  printfn "= %s %s =" (group.ToString()) (package.ToString())
+  printfn "= %s %s =" (group.ToString()) (package.GetCompareString())
   try
     let dlls = getDllFilesWithinPackage dependenciesFile (package.ToString())
     for d in dlls do

--- a/Paket.LoadingScripts/Script.fsx
+++ b/Paket.LoadingScripts/Script.fsx
@@ -1,8 +1,111 @@
-﻿// Learn more about F# at http://fsharp.org. See the 'F# Tutorial' project
-// for more guidance on F# programming.
+﻿#load "Scripts/load-project-debug.fsx"
+open System.Collections.Generic
+open System.IO
+open System.Linq
+open Mono.Cecil
+open QuickGraph
+let rootFolder        = (__SOURCE_DIRECTORY__) |> DirectoryInfo
+let dependenciesFile, lockFile =
+  let deps = Paket.Dependencies.Locate(rootFolder.FullName)
+  let lock =
+    deps.DependenciesFile
+    |> Paket.DependenciesFile.ReadFromFile
+    |> fun f -> f.FindLockfile().FullName
+    |> Paket.LockFile.LoadFrom
+  deps, lock
 
-#load "Library1.fs"
-open Paket.LoadingScripts
+let getDllFilesWithinPackage (paketDependencies: Paket.Dependencies) packageName =
+  
+  let installModel =
+    let groupName = None
+    paketDependencies.GetInstalledPackageModel(groupName, packageName)
 
-// Define your library scripting code here
+  for p in installModel.ReferenceFileFolders do
+    printfn "reference file folders: %A" p
+  
+  // HACK: take first one for now
+  let references = installModel.ReferenceFileFolders.[0].Files.References
 
+  let referenceByAssembly =
+    references
+    |> Seq.map (fun r -> (r.Path |> AssemblyDefinition.ReadAssembly), r)
+    |> dict
+
+  let assemblyByName =
+    referenceByAssembly.Keys
+    |> Seq.map (fun a -> a.Name.ToString(), a)
+    |> dict
+
+  let tryFind key (dict: IDictionary<_,_>) =
+    match dict.TryGetValue(key) with
+    | true, v -> Some v
+    | _       -> None
+
+  let graph = AdjacencyGraph<_,_>()
+  
+  for r in referenceByAssembly do
+    let assembly = r.Key
+    let paketRef = referenceByAssembly.[assembly]
+    graph.AddVertex(paketRef) |> ignore
+    let references = assembly.MainModule.AssemblyReferences
+    printfn "%A" paketRef
+    references
+    |> Seq.map (fun a -> tryFind a.FullName assemblyByName)
+    |> Seq.choose id
+    |> Seq.map (fun a -> paketRef, referenceByAssembly.[a])
+    |> Seq.iter (fun (fromRef, toRef) ->
+      graph.AddVertex(toRef) |> ignore
+      graph.AddEdge(Edge(fromRef, toRef)) |> ignore
+      )
+
+  let result =
+    let topologicalSort = Algorithms.TopologicalSort.TopologicalSortAlgorithm(graph)
+    topologicalSort.Compute()
+    topologicalSort.SortedVertices |> Seq.rev |> Seq.toArray
+
+  result
+
+let computePackageTopologyGraph (lockFile: Paket.LockFile) =
+  let lookup = Dictionary<_,_>()
+  for g in lockFile.Groups do
+    let groupName = g.Value.Name
+    let lookup =
+      let dict = Dictionary<_,_>()
+      lookup.[groupName] <- dict
+      dict
+    for r in g.Value.Resolution do
+      let package = r.Key
+      let deps =
+        lockFile.GetAllNormalizedDependenciesOf(groupName, package)
+        |> Seq.map snd
+        |> Seq.filter ((<>) package)
+        |> HashSet<_>
+      lookup.[package] <- deps
+  
+  [
+    for group in lookup.Keys do
+      let depTree = lookup.[group]
+      for package in depTree.Keys do
+        let graph = new AdjacencyGraph<_,_>()
+        graph.AddVertex(package) |> ignore
+        depTree.[package] |> Seq.iter (graph.AddVertex >> ignore)
+        depTree.[package] |> Seq.iter (fun d -> graph.AddEdge(Edge<_>(package, d)) |> ignore)
+        let depsInOrder = 
+          let sortAlgorithm = Algorithms.TopologicalSort.TopologicalSortAlgorithm<_,_>(graph)
+          sortAlgorithm.Compute()
+          sortAlgorithm.SortedVertices |> Seq.rev |> Seq.toArray
+        yield ((group, package), depsInOrder)
+  ] 
+  |> dict
+
+let packagesGraph = computePackageTopologyGraph lockFile
+
+for (group, package) in packagesGraph.Keys do
+  
+  printfn "= %s %s =" (group.ToString()) (package.ToString())
+  try
+    let dlls = getDllFilesWithinPackage dependenciesFile (package.ToString())
+    for d in dlls do
+      printfn "\t-> %s" d.Path
+  with
+  | e -> printfn "\t ERROR: %s" (e.ToString())

--- a/Paket.LoadingScripts/Scripts/load-project-debug.fsx
+++ b/Paket.LoadingScripts/Scripts/load-project-debug.fsx
@@ -1,0 +1,5 @@
+// Warning: generated file; your changes could be lost when a new file is generated.
+#I __SOURCE_DIRECTORY__
+#load "load-references-debug.fsx"
+#load "../AssemblyInfo.fs"
+      "../LoadingScriptsGenerator.fs"

--- a/Paket.LoadingScripts/Scripts/load-references-debug.fsx
+++ b/Paket.LoadingScripts/Scripts/load-references-debug.fsx
@@ -1,0 +1,15 @@
+// Warning: generated file; your changes could be lost when a new file is generated.
+#I __SOURCE_DIRECTORY__
+#r "../../packages/Chessie/lib/net40/Chessie.dll"
+#r "../../bin/Paket.Core.dll"
+#r "System.Core.dll"
+#r "System.dll"
+#r "System.Numerics.dll"
+#r "../../packages/scriptbuilder/QuickGraph/lib/net4/QuickGraph.dll"
+#r "../../packages/scriptbuilder/QuickGraph/lib/net4/QuickGraph.Data.dll"
+#r "../../packages/scriptbuilder/QuickGraph/lib/net4/QuickGraph.Graphviz.dll"
+#r "../../packages/scriptbuilder/QuickGraph/lib/net4/QuickGraph.Serialization.dll"
+#r "../../packages/scriptbuilder/Mono.Cecil/lib/net45/Mono.Cecil.dll"
+#r "../../packages/scriptbuilder/Mono.Cecil/lib/net45/Mono.Cecil.Mdb.dll"
+#r "../../packages/scriptbuilder/Mono.Cecil/lib/net45/Mono.Cecil.Pdb.dll"
+#r "../../packages/scriptbuilder/Mono.Cecil/lib/net45/Mono.Cecil.Rocks.dll"

--- a/Paket.LoadingScripts/paket.references
+++ b/Paket.LoadingScripts/paket.references
@@ -1,1 +1,6 @@
+Chessie
 FSharp.Core
+
+group ScriptBuilder
+  QuickGraph
+  Mono.Cecil

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -26,3 +26,8 @@ group Test
   nuget NUnit ~> 3
   nuget FSCheck
   github forki/FsUnit FsUnit.fs
+
+group ScriptBuilder
+  source https://nuget.org/api/v2
+  nuget QuickGraph
+  nuget Mono.Cecil

--- a/paket.lock
+++ b/paket.lock
@@ -38,6 +38,13 @@ GITHUB
   specs:
     modules/Octokit/Octokit.fsx (59dfade480c5f9107107f11af366aaae1f4a9157)
       Octokit
+GROUP ScriptBuilder
+NUGET
+  remote: https://www.nuget.org/api/v2
+  specs:
+    Mono.Cecil (0.9.6.1)
+    QuickGraph (3.6.61119.7)
+
 GROUP Test
 NUGET
   remote: https://www.nuget.org/api/v2


### PR DESCRIPTION
- add a ScriptBuilder group to paket.dependencies, right now I need Mono.Cecil and QuickGraph to get going with that work
- minor changes to LoadingScriptsGenerator.fs to have more explicit requirements in functions (depFile -> lockFile because we intend it to point to paket.lock, changed strings to DirectoryInfo and FileInfo for a bit of clarity at this point)
- changes to Paket.LoadingScripts.fsproj
- changes to Script.fs: add getDllFilesWithinPackage and computePackageTopologyGraph

getDllFilesWithinPackage is used to figure out order of dlls within a single package (for example QuickGraph contains several assemblies, this is used to figure out the order those should be referenced)

computePackageTopologyGraph is used to give the top level package names one given package depends on in order suitable for writing references recursively
