### PR TITLE
extend playground script in Paket.LoadingScripts

### DIFF
--- a/Paket.LoadingScripts/Script.fsx
+++ b/Paket.LoadingScripts/Script.fsx
@@ -1,4 +1,5 @@
 ﻿#load "Scripts/load-project-debug.fsx"
+open System
 open System.Collections.Generic
 open System.IO
 open System.Linq
@@ -16,17 +17,31 @@ let dependenciesFile, lockFile =
     |> Paket.LockFile.LoadFrom
   deps, lock
 
-let getDllFilesWithinPackage (paketDependencies: Paket.Dependencies) packageName =
+let tryFind key (dict: IDictionary<_,_>) =
+  match dict.TryGetValue(key) with
+  | true, v -> Some v
+  | _       -> None
+
+let getDllFilesWithinPackage (paketDependencies: Paket.Dependencies) (targetPredicate: _ -> Paket.LibFolder option) packageName =
   
   let installModel =
     let groupName = None
     paketDependencies.GetInstalledPackageModel(groupName, packageName)
-
-  // HACK: take first one for now
-  let references = installModel.ReferenceFileFolders.[0].Files.References
+  let libFolder = 
+    targetPredicate installModel.ReferenceFileFolders
+    (**installModel.ReferenceFileFolders
+    |> Seq.map (fun f -> f, targetPredicate f)
+    |> Seq.choose (snd >> id)
+    |> Seq.tryHead*)
+  
+  let references = 
+    match libFolder with
+    | None        -> Set.empty
+    | Some folder -> folder.Files.References
 
   let referenceByAssembly =
     references
+    |> Seq.filter (fun f -> f.LibName.IsSome)
     |> Seq.map (fun r -> (r.Path |> AssemblyDefinition.ReadAssembly), r)
     |> dict
 
@@ -34,11 +49,6 @@ let getDllFilesWithinPackage (paketDependencies: Paket.Dependencies) packageName
     referenceByAssembly.Keys
     |> Seq.map (fun a -> a.Name.ToString(), a)
     |> dict
-
-  let tryFind key (dict: IDictionary<_,_>) =
-    match dict.TryGetValue(key) with
-    | true, v -> Some v
-    | _       -> None
 
   let graph = AdjacencyGraph<_,_>()
   
@@ -97,14 +107,90 @@ let computePackageTopologyGraph (lockFile: Paket.LockFile) =
   ] 
   |> dict
 
+let weightTargetProfiles possibleFrameworksInOrderOfPreference (profiles: Paket.TargetProfile list) =
+  
+  let relevantFrameworksWithPreferenceIndex =
+    possibleFrameworksInOrderOfPreference
+    |> Seq.mapi (fun i f -> f, i)
+    |> dict
+  
+  let profileWithAllFrameworks =
+    profiles
+    |> Seq.map (fun targetProfile ->
+      targetProfile, 
+      match targetProfile with
+      | Paket.SinglePlatform platform -> [platform]
+      | Paket.PortableProfile (_, platforms) -> platforms
+    )
+    |> Seq.map (fun (targetProfile, profiles) ->
+      targetProfile, 
+      profiles
+      |> Seq.map (fun p -> p, tryFind p relevantFrameworksWithPreferenceIndex)
+    )
+  
+  // we pick the first one for which the sum of prefered indexes is the lowest
+  let choices = 
+    profileWithAllFrameworks
+    |> Seq.map (fun (targetProfile, selection) -> 
+      let sum =
+        let selectionWithMatches =
+          selection
+          |> Seq.filter (snd >> Option.isSome)
+        if selectionWithMatches |> Seq.isEmpty then
+          Int32.MaxValue
+        else
+          selectionWithMatches
+          |> Seq.map (snd)
+          |> Seq.choose id
+          |> Seq.sum
+      targetProfile,sum
+    )
+    |> Seq.filter (snd >> ((<>) Int32.MaxValue))
+  choices
+
+let makeTargetPredicate frameworks =
+  fun (folders: Paket.LibFolder list) ->
+    folders
+    |> Seq.map (fun folder-> folder, weightTargetProfiles frameworks folder.Targets)
+    |> Seq.map (fun (folder, weightedTargetProfiles) -> 
+      folder, weightedTargetProfiles |> Seq.sumBy snd
+    )
+    |> Seq.sortBy snd
+    |> Seq.map fst
+    |> Seq.tryHead
+
+let frameworkIdentifiersInPreferenceOrder =
+  [
+  Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_5
+  Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_Client
+  Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V3_5
+  Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V2
+  ]
+
+let profiles = dependenciesFile.GetInstalledPackageModel(None, "Chessie")
+for refFolder in profiles.ReferenceFileFolders do
+  printfn "%A" (weightTargetProfiles frameworkIdentifiersInPreferenceOrder refFolder.Targets)
+
+let targetPredicate = makeTargetPredicate frameworkIdentifiersInPreferenceOrder
+
+getDllFilesWithinPackage dependenciesFile targetPredicate ("fspickler")
+
 let packagesGraph = computePackageTopologyGraph lockFile
 
 for (group, package) in packagesGraph.Keys do
   
   printfn "= %s %s =" (group.ToString()) (package.GetCompareString())
   try
-    let dlls = getDllFilesWithinPackage dependenciesFile (package.ToString())
+    let dlls = getDllFilesWithinPackage dependenciesFile targetPredicate (package.ToString())
     for d in dlls do
       printfn "\t-> %s" d.Path
   with
   | e -> printfn "\t ERROR: %s" (e.ToString())
+
+let installModel = dependenciesFile.GetInstalledPackageModel(Some "main", "newtonsoft.json")
+
+for p in installModel.ReferenceFileFolders do
+  let folderName = p.Name
+  printfn "%s" folderName
+  for t in p.Targets do
+    printfn "\t-> %A" t


### PR DESCRIPTION
- getDllFilesWithinPackage now takes a targetPredicate which allows to identify the correct Paket.LibFolder
- add weightTargetProfiles and makeTargetPredicate functions

weightTargetProfiles takes a list of Paket.FrameworkIdentifier (in order of preference) and a list of Paket.TargetProfile and weight each profile (lower weight is considered favored)

makeTargetPredicate is helper function to make a suitable predicate for getDllFilesWithinPackage given list of prefered Paket.FrameworkIdentifier
