### PR TITLE
integrating better resolution of dll files

### DIFF
--- a/Paket.LoadingScripts/LoadingScriptsGenerator.fs
+++ b/Paket.LoadingScripts/LoadingScriptsGenerator.fs
@@ -83,8 +83,121 @@ module LoadingScriptsGenerator =
 
 module ScriptGeneratingModule =
   open System.IO
+  open System.Collections.Generic
+  open Mono.Cecil
+  open QuickGraph
+  open System
+
+  let private listOfFrameworks = [
+    Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_5
+    Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V4_Client
+    Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V3_5
+    Paket.FrameworkIdentifier.DotNetFramework Paket.FrameworkVersion.V2
+  ]
+
+  let tryFind key (dict: IDictionary<_,_>) =
+    match dict.TryGetValue(key) with
+    | true, v -> Some v
+    | _       -> None
+  let weightTargetProfiles possibleFrameworksInOrderOfPreference (profiles: Paket.TargetProfile list) =
+  
+    let relevantFrameworksWithPreferenceIndex =
+      possibleFrameworksInOrderOfPreference
+      |> Seq.mapi (fun i f -> f, i)
+      |> dict
+  
+    let profileWithAllFrameworks =
+      profiles
+      |> Seq.map (fun targetProfile ->
+        targetProfile, 
+        match targetProfile with
+        | Paket.SinglePlatform platform -> [platform]
+        | Paket.PortableProfile (_, platforms) -> platforms
+      )
+      |> Seq.map (fun (targetProfile, profiles) ->
+        targetProfile, 
+        profiles
+        |> Seq.map (fun p -> p, tryFind p relevantFrameworksWithPreferenceIndex)
+      )
+  
+    // we pick the first one for which the sum of prefered indexes is the lowest
+    let choices = 
+      profileWithAllFrameworks
+      |> Seq.map (fun (targetProfile, selection) -> 
+        let sum =
+          let selectionWithMatches =
+            selection
+            |> Seq.filter (snd >> Option.isSome)
+          if selectionWithMatches |> Seq.isEmpty then
+            Int32.MaxValue
+          else
+            selectionWithMatches
+            |> Seq.map (snd)
+            |> Seq.choose id
+            |> Seq.sum
+        targetProfile,sum
+      )
+      |> Seq.filter (snd >> ((<>) Int32.MaxValue))
+    choices
+
+  let makeTargetPredicate frameworks =
+    fun (folders: Paket.LibFolder list) ->
+      folders
+      |> Seq.map (fun folder-> folder, weightTargetProfiles frameworks folder.Targets)
+      |> Seq.map (fun (folder, weightedTargetProfiles) -> 
+        folder, weightedTargetProfiles |> Seq.sumBy snd
+      )
+      |> Seq.sortBy snd
+      |> Seq.map fst
+      |> Seq.tryHead
+
+  let getDllFilesWithinPackage (paketDependencies: Paket.Dependencies) (targetPredicate: _ -> Paket.LibFolder option) groupName packageName =
+  
+    let installModel = paketDependencies.GetInstalledPackageModel(groupName, packageName)
+    let libFolder = targetPredicate installModel.ReferenceFileFolders
+  
+    let references = 
+      match libFolder with
+      | None        -> Set.empty
+      | Some folder -> folder.Files.References
+
+    let referenceByAssembly =
+      references
+      |> Seq.filter (fun f -> f.LibName.IsSome)
+      |> Seq.map (fun r -> (r.Path |> AssemblyDefinition.ReadAssembly), r)
+      |> dict
+
+    let assemblyByName =
+      referenceByAssembly.Keys
+      |> Seq.map (fun a -> a.Name.ToString(), a)
+      |> dict
+
+    let graph = AdjacencyGraph<_,_>()
+  
+    for r in referenceByAssembly do
+      let assembly = r.Key
+      let paketRef = referenceByAssembly.[assembly]
+      graph.AddVertex(paketRef) |> ignore
+      let references = assembly.MainModule.AssemblyReferences
+      printfn "%A" paketRef
+      references
+      |> Seq.map (fun a -> tryFind a.FullName assemblyByName)
+      |> Seq.choose id
+      |> Seq.map (fun a -> paketRef, referenceByAssembly.[a])
+      |> Seq.iter (fun (fromRef, toRef) ->
+        graph.AddVertex(toRef) |> ignore
+        graph.AddEdge(Edge(fromRef, toRef)) |> ignore
+        )
+
+    let result =
+      let topologicalSort = Algorithms.TopologicalSort.TopologicalSortAlgorithm(graph)
+      topologicalSort.Compute()
+      topologicalSort.SortedVertices |> Seq.rev |> Seq.toArray
+
+    result
+
   let getScriptName (package: PackageName) = sprintf "Include_%s.fsx" (package.GetCompareString())
-  let generateFSharpScript (packagesOrGroupFolder: DirectoryInfo) (knownIncludeScripts:Map<PackageName, string>) (package: PackageResolver.ResolvedPackage) =
+  let generateFSharpScript dependenciesFile lockFile (packagesOrGroupFolder: DirectoryInfo) (knownIncludeScripts:Map<PackageName, string>) (package: PackageResolver.ResolvedPackage) =
     let packageFolder = 
       Path.Combine (packagesOrGroupFolder.FullName, package.Name.GetCompareString())
       |> DirectoryInfo
@@ -94,28 +207,17 @@ module ScriptGeneratingModule =
     let depLines =
       package.Dependencies
       |> Seq.map (fun (depName,_,_) -> sprintf "#load \"../%s\"" ((knownIncludeScripts |> Map.find depName).Replace("\\", "/")))
+    
+    let toRelative = (Path.GetFullPath >> (fun f -> f.Substring(packageFolder.FullName.Length + 1)))
 
     let dllFiles =
       if package.Name.GetCompareString().ToLowerInvariant() = "fsharp.core" then
         Seq.empty
       else
-        let libDir = Path.Combine (packageFolder.FullName, "lib")
-        // TODO: Replace with some intelligent code to use the correct framework dlls,
-        // Generate multiple include scripts per-framework.
-        let net40 = Path.Combine (libDir, "net40")
-        let net45 = Path.Combine (libDir, "net45")
-        let toRelative seq =
-          seq
-          |> Seq.map (Path.GetFullPath >> (fun f -> f.Substring(packageFolder.FullName.Length + 1)))
-        if (Directory.Exists net45) then
-          Directory.EnumerateFiles(net45, "*.dll")
-          |> toRelative
-        elif (Directory.Exists net40) then
-          Directory.EnumerateFiles(net40, "*.dll")
-          |> toRelative
-        else
-          printfn "Could not find either 'net45' nor 'net40' folder for package '%s'" (package.Name.GetCompareString())
-          Seq.empty
+        let group = None
+        let references = getDllFilesWithinPackage dependenciesFile (makeTargetPredicate listOfFrameworks) group (package.Name.GetCompareString())
+        references
+        |> Seq.map (fun r -> toRelative r.Path)
 
     let orderedDllFiles =
       // TODO: Order by the inter-dependencies
@@ -132,26 +234,30 @@ module ScriptGeneratingModule =
     |> fun lines -> Seq.append lines dllLines
     |> fun lines -> Seq.append lines [ sprintf "printfn \"%%s\" \"Loaded %s\"" (package.Name.GetCompareString()) ]
     |> fun lines -> File.WriteAllLines (scriptFile, lines)
-
-
     
     knownIncludeScripts |> Map.add package.Name relScriptFile
     
   // Generate a fsharp script from the given order of packages, if a package is ordered before its dependencies this function will throw.
-  let generateFSharpScripts packagesOrGroupFolder (orderedPackages: PackageResolver.ResolvedPackage list) =
+  let generateFSharpScripts dependenciesFile lockFile packagesOrGroupFolder (orderedPackages: PackageResolver.ResolvedPackage list) =
       orderedPackages
       |> Seq.fold (fun (knownIncludeScripts) p ->
-        generateFSharpScript packagesOrGroupFolder knownIncludeScripts p) Map.empty
+        generateFSharpScript dependenciesFile lockFile packagesOrGroupFolder knownIncludeScripts p) Map.empty
       |> ignore
 
         
   // Generate a fsharp script from the given order of packages, if a package is ordered before its dependencies this function will throw.
   let generateFSharpScriptsForRootFolder (rootFolder: DirectoryInfo) =
-      let lockFile =
-          Path.Combine(rootFolder.FullName, "paket.lock")
-          |> FileInfo
-
-      let dependencies = LoadingScriptsGenerator.getPackageOrderFromDependenciesFile lockFile
+      
+      let dependenciesFile, lockFile =
+          let deps = Paket.Dependencies.Locate(rootFolder.FullName)
+          let lock =
+            deps.DependenciesFile
+            |> Paket.DependenciesFile.ReadFromFile
+            |> fun f -> f.FindLockfile().FullName
+            |> Paket.LockFile.LoadFrom
+          deps, lock
+      
+      let dependencies = LoadingScriptsGenerator.getPackageOrderFromDependenciesFile (FileInfo(lockFile.FileName))
       
       let packagesFolder =
         Path.Combine(rootFolder.FullName, "packages")
@@ -163,7 +269,7 @@ module ScriptGeneratingModule =
           match groupName.GetCompareString () with
           | "main"    -> packagesFolder 
           | groupName -> Path.Combine(packagesFolder.FullName, groupName) |> DirectoryInfo
-        generateFSharpScripts packagesOrGroupFolder packages
+        generateFSharpScripts dependenciesFile lockFile packagesOrGroupFolder packages
         )
       |> ignore
       

--- a/Paket.LoadingScripts/Script.fsx
+++ b/Paket.LoadingScripts/Script.fsx
@@ -7,8 +7,8 @@ open Mono.Cecil
 open QuickGraph
 
 let dependenciesFile, lockFile =
-  //let rootFolder = (@"C:\dev\src\g\fiddle3d") |> DirectoryInfo
-  let rootFolder = (__SOURCE_DIRECTORY__) |> DirectoryInfo
+  let rootFolder = (@"C:\dev\src\g\fiddle3d") |> DirectoryInfo
+  //let rootFolder = (__SOURCE_DIRECTORY__) |> DirectoryInfo
   let deps = Paket.Dependencies.Locate(rootFolder.FullName)
   let lock =
     deps.DependenciesFile
@@ -17,62 +17,13 @@ let dependenciesFile, lockFile =
     |> Paket.LockFile.LoadFrom
   deps, lock
 
-let tryFind key (dict: IDictionary<_,_>) =
-  match dict.TryGetValue(key) with
-  | true, v -> Some v
-  | _       -> None
+Paket.LoadingScripts.ScriptGeneratingModule.generateFSharpScriptsForRootFolder ((@"C:\dev\src\g\fiddle3d") |> DirectoryInfo)
 
-let getDllFilesWithinPackage (paketDependencies: Paket.Dependencies) (targetPredicate: _ -> Paket.LibFolder option) packageName =
-  
-  let installModel =
-    let groupName = None
-    paketDependencies.GetInstalledPackageModel(groupName, packageName)
-  let libFolder = 
-    targetPredicate installModel.ReferenceFileFolders
-    (**installModel.ReferenceFileFolders
-    |> Seq.map (fun f -> f, targetPredicate f)
-    |> Seq.choose (snd >> id)
-    |> Seq.tryHead*)
-  
-  let references = 
-    match libFolder with
-    | None        -> Set.empty
-    | Some folder -> folder.Files.References
-
-  let referenceByAssembly =
-    references
-    |> Seq.filter (fun f -> f.LibName.IsSome)
-    |> Seq.map (fun r -> (r.Path |> AssemblyDefinition.ReadAssembly), r)
-    |> dict
-
-  let assemblyByName =
-    referenceByAssembly.Keys
-    |> Seq.map (fun a -> a.Name.ToString(), a)
-    |> dict
-
-  let graph = AdjacencyGraph<_,_>()
-  
-  for r in referenceByAssembly do
-    let assembly = r.Key
-    let paketRef = referenceByAssembly.[assembly]
-    graph.AddVertex(paketRef) |> ignore
-    let references = assembly.MainModule.AssemblyReferences
-    printfn "%A" paketRef
-    references
-    |> Seq.map (fun a -> tryFind a.FullName assemblyByName)
-    |> Seq.choose id
-    |> Seq.map (fun a -> paketRef, referenceByAssembly.[a])
-    |> Seq.iter (fun (fromRef, toRef) ->
-      graph.AddVertex(toRef) |> ignore
-      graph.AddEdge(Edge(fromRef, toRef)) |> ignore
-      )
-
-  let result =
-    let topologicalSort = Algorithms.TopologicalSort.TopologicalSortAlgorithm(graph)
-    topologicalSort.Compute()
-    topologicalSort.SortedVertices |> Seq.rev |> Seq.toArray
-
-  result
+(*
+let tryFind = Paket.LoadingScripts.ScriptGeneratingModule.tryFind
+let weightTargetProfiles = Paket.LoadingScripts.ScriptGeneratingModule.weightTargetProfiles
+let makeTargetPredicate = Paket.LoadingScripts.ScriptGeneratingModule.makeTargetPredicate
+let getDllFilesWithinPackage = Paket.LoadingScripts.ScriptGeneratingModule.getDllFilesWithinPackage
 
 let computePackageTopologyGraph (lockFile: Paket.LockFile) =
   let lookup = Dictionary<_,_>()
@@ -107,57 +58,6 @@ let computePackageTopologyGraph (lockFile: Paket.LockFile) =
   ] 
   |> dict
 
-let weightTargetProfiles possibleFrameworksInOrderOfPreference (profiles: Paket.TargetProfile list) =
-  
-  let relevantFrameworksWithPreferenceIndex =
-    possibleFrameworksInOrderOfPreference
-    |> Seq.mapi (fun i f -> f, i)
-    |> dict
-  
-  let profileWithAllFrameworks =
-    profiles
-    |> Seq.map (fun targetProfile ->
-      targetProfile, 
-      match targetProfile with
-      | Paket.SinglePlatform platform -> [platform]
-      | Paket.PortableProfile (_, platforms) -> platforms
-    )
-    |> Seq.map (fun (targetProfile, profiles) ->
-      targetProfile, 
-      profiles
-      |> Seq.map (fun p -> p, tryFind p relevantFrameworksWithPreferenceIndex)
-    )
-  
-  // we pick the first one for which the sum of prefered indexes is the lowest
-  let choices = 
-    profileWithAllFrameworks
-    |> Seq.map (fun (targetProfile, selection) -> 
-      let sum =
-        let selectionWithMatches =
-          selection
-          |> Seq.filter (snd >> Option.isSome)
-        if selectionWithMatches |> Seq.isEmpty then
-          Int32.MaxValue
-        else
-          selectionWithMatches
-          |> Seq.map (snd)
-          |> Seq.choose id
-          |> Seq.sum
-      targetProfile,sum
-    )
-    |> Seq.filter (snd >> ((<>) Int32.MaxValue))
-  choices
-
-let makeTargetPredicate frameworks =
-  fun (folders: Paket.LibFolder list) ->
-    folders
-    |> Seq.map (fun folder-> folder, weightTargetProfiles frameworks folder.Targets)
-    |> Seq.map (fun (folder, weightedTargetProfiles) -> 
-      folder, weightedTargetProfiles |> Seq.sumBy snd
-    )
-    |> Seq.sortBy snd
-    |> Seq.map fst
-    |> Seq.tryHead
 
 let frameworkIdentifiersInPreferenceOrder =
   [
@@ -173,7 +73,7 @@ for refFolder in profiles.ReferenceFileFolders do
 
 let targetPredicate = makeTargetPredicate frameworkIdentifiersInPreferenceOrder
 
-getDllFilesWithinPackage dependenciesFile targetPredicate ("fspickler")
+getDllFilesWithinPackage dependenciesFile targetPredicate None ("fspickler")
 
 let packagesGraph = computePackageTopologyGraph lockFile
 
@@ -181,7 +81,7 @@ for (group, package) in packagesGraph.Keys do
   
   printfn "= %s %s =" (group.ToString()) (package.GetCompareString())
   try
-    let dlls = getDllFilesWithinPackage dependenciesFile targetPredicate (package.ToString())
+    let dlls = getDllFilesWithinPackage dependenciesFile targetPredicate (None) (package.ToString())
     for d in dlls do
       printfn "\t-> %s" d.Path
   with
@@ -194,3 +94,4 @@ for p in installModel.ReferenceFileFolders do
   printfn "%s" folderName
   for t in p.Targets do
     printfn "\t-> %A" t
+*)


### PR DESCRIPTION
- load dependency and lock files in generateFSharpScriptsForRootFolder, pass those down to lower level functions
- migrate and integrate weightTargetProfiles, makeTargetPredicate and getDllFilesWithinPackage in generateFSharpScript
