### PR TITLE
only generate a script if includes, references or loads would be written

### DIFF
--- a/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
+++ b/integrationtests/Paket.IntegrationTests/LoadingScriptGenerationTests.fs
@@ -17,7 +17,7 @@ let getGeneratedScriptFiles framework scenario =
   
   directory.GetFiles()
 
-[<Test>]
+[<Test; Category("scriptgen")>]
 let ``simple dependencies generates expected scripts``() = 
   let scenario = "simple-dependencies"
   let framework = "net4"
@@ -38,7 +38,7 @@ let ``simple dependencies generates expected scripts``() =
   Assert.AreEqual(expectedFiles, actualFiles)
   
 
-[<Test>]
+[<Test;Category("scriptgen")>]
 let ``framework specified``() = 
   let scenario = "framework-specified"
   paket "install" scenario |> ignore

--- a/integrationtests/scenarios/loading-scripts-scenarios/no-references/before/paket.dependencies
+++ b/integrationtests/scenarios/loading-scripts-scenarios/no-references/before/paket.dependencies
@@ -1,0 +1,3 @@
+source http://nuget.org/api/v2
+
+nuget FAKE


### PR DESCRIPTION
merge/rebase at your leisure.

Other options include changing the signature of the script generation function to `string seq option` and doing option matching to make it more explicit that we sometimes are ok with a script not being generated.
